### PR TITLE
support version command

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -34,6 +34,7 @@ var RootCmd = &cobra.Command{
 func init() {
 	RootCmd.PersistentFlags().StringVar(&kubeConfig, "kubeconfig", filepath.Join(homedir.HomeDir(), ".kube", "config"), "path of the kubernetes config file")
 	RootCmd.AddCommand(studioCmd())
+	RootCmd.AddCommand(versionCmd())
 	RootCmd.AddCommand(listCmd())
 	RootCmd.AddCommand(useCmd())
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2023 The nebula-contrib Authors.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package cmd
+
+import (
+	"context"
+	"log"
+
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/nebula-contrib/ngctl/pkg/util"
+	"github.com/nebula-contrib/ngctl/pkg/version"
+)
+
+const OperatorSelector = "app.kubernetes.io/component=controller-manager,app.kubernetes.io/instance=nebula-operator"
+
+func versionCmd() *cobra.Command {
+	var (
+		namespace string
+	)
+	cmd := &cobra.Command{
+		Use:   "version",
+		Short: "show the version of ngctl and nebula operator",
+		Long:  "show the version of ngctl and nebula operator.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return ngctlVersion(namespace)
+		},
+	}
+	cmd.PersistentFlags().StringVar(&namespace, "operator-namespace", "nebula-operator-system", "namespace of nebula operator")
+	return cmd
+}
+
+func ngctlVersion(namespace string) error {
+	log.Printf("ngctl Version: %s", version.GetVersion())
+	set, err := util.NewClientSet(kubeConfig)
+	if err != nil {
+		return err
+	}
+	ctx := context.Background()
+
+	controllers, err := set.AppsV1().Deployments(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: OperatorSelector,
+	})
+	if err != nil {
+		return err
+	}
+	if len(controllers.Items) == 0 {
+		log.Printf("nebula operator is not installed")
+		return nil
+	}
+	log.Printf("Nebula Operator Version: %s", controllers.Items[0].Spec.Template.Spec.Containers[0].Image)
+	return nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2023 The nebula-contrib Authors.
+ * Licensed under the Apache License, GitVersion 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package version
+
+import "fmt"
+
+var (
+	VerMajor = 0
+	VerMinor = 0
+	VerPatch = 1
+	VerName  = "Nebula Operator Command Line Tool"
+	GitSha   = "UNKNOWN"
+	GitRef   = "UNKNOWN"
+)
+
+func GetVersion() string {
+	return fmt.Sprintf(`%s,V-%d.%d.%d [GitSha: %s GitRef: %s]`,
+		VerName, VerMajor, VerMinor, VerPatch, GitSha, GitRef)
+}


### PR DESCRIPTION
This PR adds version command to show the version of ngctl and nebula operator.

The changes include:

- show ngctl version
- show nebula operator version

fix #5 

version can be injected as follows:
```sh
go build -ldflags "-X github.com/nebula-contrib/ngctl/pkg/version.GitRef=main"
```